### PR TITLE
fix: call set_page_config first in Streamlit app

### DIFF
--- a/frontend/chat_ui.py
+++ b/frontend/chat_ui.py
@@ -1,6 +1,9 @@
 import streamlit as st
 import requests
 
+# st.set_page_config must be the first Streamlit command
+st.set_page_config(page_title="Groq Chatbot", page_icon="🧠", layout="centered")
+
 st.markdown("""
     <style>
         html, body, [class*="css"] {
@@ -9,9 +12,6 @@ st.markdown("""
         }
     </style>
 """, unsafe_allow_html=True)
-
-
-st.set_page_config(page_title="Groq Chatbot", page_icon="🧠", layout="centered")
 
 st.markdown(
     "<h1 style='text-align: center; color: #4A90E2;'>🧠 Groq Chatbot</h1>", 


### PR DESCRIPTION
## Summary
- ensure st.set_page_config is the first Streamlit call in chat_ui to avoid runtime errors

## Testing
- `pytest`
- `python -m py_compile frontend/chat_ui.py backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688f78eb2754832294424124262b3e5e